### PR TITLE
Fix broken link

### DIFF
--- a/timeline_v3.html
+++ b/timeline_v3.html
@@ -3314,7 +3314,7 @@
       <b id="bib-Wall_2014">Wall 2014</b>:
       Wall, Larry.
       <mla_container>IRC log for #perl6</mla_container>, 30 August 2014,
-      <a href="https://irclog.perlgeek.de/perl6/2014-08-30#i_9271280">https://irclog.perlgeek.de/perl6/2014-08-30#i_9271280</a>.
+      <a href="https://logs.liz.nl/perl6/2014-08-30.html#16:10">https://logs.liz.nl/perl6/2014-08-30.html#16:10</a>.
       Accessed 25 April 2018.
     </p>
     <p>


### PR DESCRIPTION
The IRC link you had doesn't work. perlgeek felt they had unacceptable theoretical legal exposure due to the EU's GDPR laws. So they ended the service. Using the archive.org link would perhaps sustain that exposure, so using that instead seems inappropriate too.

So I've updated the link (href and text) to refer to the de facto replacement service. (Liz isn't afraid of the theoretical exposure.) Aiui Liz has paid ahead for 10 years worth of hosting/domain/etc so it should be fairly reliable. That said, I've also made sure archive.org has the new page, and that will perhaps be an even safer bet. Using that would perhaps be even more appropriate, especially if you've donated to archive.org. If you want to use archive.org then the URL I suggest is https://web.archive.org/web/20211015215851/https://logs.liz.nl/perl6/2014-08-30.html#16:09-0004. That URL actually links to your question rather than Larry's line where he begins to answer your question, but I did that because the archive.org display semi-obscures the immediately linked line in some browsers.